### PR TITLE
fix(RestSharp): Remove N8.NetTools.HTTP for Resharp

### DIFF
--- a/ntfy.Tests/ntfy.Tests.csproj
+++ b/ntfy.Tests/ntfy.Tests.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0"/>
+        <PackageReference Include="xunit" Version="2.4.1"/>
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -22,7 +22,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\ntfy\ntfy.csproj" />
+        <ProjectReference Include="..\ntfy\ntfy.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/ntfy/Actions/Http.cs
+++ b/ntfy/Actions/Http.cs
@@ -10,6 +10,33 @@ namespace ntfy.Actions;
 /// </summary>
 public class Http : Action
 {
+    /// <summary>
+    ///     Constructor for an Http action.
+    /// </summary>
+    /// <param name="label">The label for the action.</param>
+    /// <param name="url">The URL to which the HTTP request will be sent.</param>
+    public Http(string label, Uri url) : base(label)
+    {
+        Url = url;
+    }
+
+    /// <summary>
+    ///     The type of this action, as an <see cref="ActionType" /> enum.
+    /// </summary>
+    [JsonIgnore]
+    public override ActionType Type { get; } = ActionType.Http;
+
+    /// <summary>
+    ///     The HTTP method to use when sending the request.
+    ///     Defaults to <c>HttpMethod.Post</c>
+    /// </summary>
+    [JsonIgnore]
+    public HttpMethod? Method
+    {
+        get => new(MethodString!);
+        set => MethodString = value?.Method;
+    }
+
     #region JSON Properties
 
     /// <summary>
@@ -47,31 +74,4 @@ public class Http : Action
     public Uri Url { get; set; }
 
     #endregion
-
-    /// <summary>
-    ///     The type of this action, as an <see cref="ActionType" /> enum.
-    /// </summary>
-    [JsonIgnore]
-    public override ActionType Type { get; } = ActionType.Http;
-
-    /// <summary>
-    ///     The HTTP method to use when sending the request.
-    ///     Defaults to <c>HttpMethod.Post</c>
-    /// </summary>
-    [JsonIgnore]
-    public HttpMethod? Method
-    {
-        get => new(MethodString!);
-        set => MethodString = value?.Method;
-    }
-
-    /// <summary>
-    ///     Constructor for an Http action.
-    /// </summary>
-    /// <param name="label">The label for the action.</param>
-    /// <param name="url">The URL to which the HTTP request will be sent.</param>
-    public Http(string label, Uri url) : base(label)
-    {
-        Url = url;
-    }
 }

--- a/ntfy/Actions/View.cs
+++ b/ntfy/Actions/View.cs
@@ -10,6 +10,22 @@ namespace ntfy.Actions;
 /// </summary>
 public class View : Action
 {
+    /// <summary>
+    ///     Constructor for a View action.
+    /// </summary>
+    /// <param name="label">The label for the action.</param>
+    /// <param name="url">The URL to open when the action is tapped.</param>
+    public View(string label, Uri url) : base(label)
+    {
+        Url = url;
+    }
+
+    /// <summary>
+    ///     The type of this action, as an <see cref="ActionType" /> enum.
+    /// </summary>
+    [JsonIgnore]
+    public override ActionType Type { get; } = ActionType.View;
+
     #region JSON Properties
 
     /// <summary>
@@ -26,20 +42,4 @@ public class View : Action
     public Uri Url { get; set; }
 
     #endregion
-
-    /// <summary>
-    ///     The type of this action, as an <see cref="ActionType" /> enum.
-    /// </summary>
-    [JsonIgnore]
-    public override ActionType Type { get; } = ActionType.View;
-
-    /// <summary>
-    ///     Constructor for a View action.
-    /// </summary>
-    /// <param name="label">The label for the action.</param>
-    /// <param name="url">The URL to open when the action is tapped.</param>
-    public View(string label, Uri url) : base(label)
-    {
-        Url = url;
-    }
 }

--- a/ntfy/Requests/SendingMessage.cs
+++ b/ntfy/Requests/SendingMessage.cs
@@ -1,5 +1,4 @@
 using NetTools;
-using NetTools.HTTP;
 using Newtonsoft.Json;
 using ntfy.Actions;
 using ntfy.Filters;
@@ -12,107 +11,6 @@ namespace ntfy.Requests;
 /// </summary>
 public class SendingMessage
 {
-    #region JSON Properties
-
-    /// <summary>
-    ///     A list of actions to include in this message.
-    ///     Available actions include <see cref="View" />, <see cref="Broadcast" /> and
-    ///     <see cref="ntfy.Actions.Http" />.
-    /// </summary>
-    [JsonProperty("actions", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public Action[]? Actions { get; set; }
-
-    /// <summary>
-    ///     A URL to send as an attachment in this message.
-    ///     This is an alternative to sending the file itself to the server via <see cref="Filename" />.
-    /// </summary>
-    [JsonProperty("attach", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public Uri? Attach { get; set; }
-
-    /// <summary>
-    ///     The URL to open when the associated notification for this message is clicked.
-    /// </summary>
-    [JsonProperty("click", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public Uri? Click { get; set; }
-
-    [JsonProperty("email", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public string? Email { get; set; }
-
-    /// <summary>
-    ///     The filename of the file to include in this message.
-    ///     This file will be sent to the server. If you want to send a URL instead, use <see cref="Attach" /> instead.
-    /// </summary>
-    [JsonProperty("filename", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public string? Filename { get; set; }
-
-    /// <summary>
-    ///     The URL to send as the associated notification's icon.
-    /// </summary>
-    [JsonProperty("icon", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public string? Icon { get; set; }
-
-    /// <summary>
-    ///     The main body of this message to show in the associated notification.
-    /// </summary>
-    [JsonProperty("message", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public string? Message { get; set; }
-
-    /// <summary>
-    ///     Tags to include in the message.
-    /// </summary>
-    [JsonProperty("tags", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public string[]? Tags { get; set; }
-
-    /// <summary>
-    ///     The title of this message.
-    /// </summary>
-    [JsonProperty("title", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    public string? Title { get; set; }
-
-    /// <summary>
-    ///     The topic to send this message to.
-    ///     This parameter is set internally during the sending process, and should not be set manually by the user.
-    /// </summary>
-    [JsonProperty("topic", Required = Required.Always)]
-    internal string Topic { get; set; } = null!;
-
-    /// <summary>
-    ///     Whether to enable or disable caching for this message, as a string.
-    ///     This representation is used by API calls, and is hidden from end users.
-    /// </summary>
-    [JsonProperty("cache", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    private string CacheString { get; set; } = "yes";
-
-    /// <summary>
-    ///     The string representation of the delay to wait before sending this message.
-    ///     This representation is used by API calls, and is hidden from end users.
-    /// </summary>
-    [JsonProperty("delay", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    private string? DelayString { get; set; }
-
-    /// <summary>
-    ///     Whether to enable or disable sending this message to Firebase, as a string.
-    ///     This representation is used by API calls, and is hidden from end users.
-    /// </summary>
-    [JsonProperty("firebase", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    private string FirebaseString { get; set; } = "yes";
-
-    /// <summary>
-    ///     The priority level of this message, as an integer.
-    ///     This representation is used by API calls, and is hidden from end users.
-    /// </summary>
-    [JsonProperty("priority", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    private int? PriorityInt { get; set; }
-
-    /// <summary>
-    ///     Whether to enable or disable UnifiedPush for this message, as a string.
-    ///     This representation is used by API calls, and is hidden from end users.
-    /// </summary>
-    [JsonProperty("unifiedpush", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
-    private int UnifiedPushInt { get; set; }
-
-    #endregion
-
     /// <summary>
     ///     Whether to enable or disable caching for this message.
     /// </summary>
@@ -234,6 +132,107 @@ public class SendingMessage
     internal string ToData(string topic)
     {
         Topic = topic;
-        return JsonSerialization.ConvertObjectToJson(this);
+        return JsonConvert.SerializeObject(this);
     }
+
+    #region JSON Properties
+
+    /// <summary>
+    ///     A list of actions to include in this message.
+    ///     Available actions include <see cref="View" />, <see cref="Broadcast" /> and
+    ///     <see cref="ntfy.Actions.Http" />.
+    /// </summary>
+    [JsonProperty("actions", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public Action[]? Actions { get; set; }
+
+    /// <summary>
+    ///     A URL to send as an attachment in this message.
+    ///     This is an alternative to sending the file itself to the server via <see cref="Filename" />.
+    /// </summary>
+    [JsonProperty("attach", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public Uri? Attach { get; set; }
+
+    /// <summary>
+    ///     The URL to open when the associated notification for this message is clicked.
+    /// </summary>
+    [JsonProperty("click", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public Uri? Click { get; set; }
+
+    [JsonProperty("email", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public string? Email { get; set; }
+
+    /// <summary>
+    ///     The filename of the file to include in this message.
+    ///     This file will be sent to the server. If you want to send a URL instead, use <see cref="Attach" /> instead.
+    /// </summary>
+    [JsonProperty("filename", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public string? Filename { get; set; }
+
+    /// <summary>
+    ///     The URL to send as the associated notification's icon.
+    /// </summary>
+    [JsonProperty("icon", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public string? Icon { get; set; }
+
+    /// <summary>
+    ///     The main body of this message to show in the associated notification.
+    /// </summary>
+    [JsonProperty("message", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public string? Message { get; set; }
+
+    /// <summary>
+    ///     Tags to include in the message.
+    /// </summary>
+    [JsonProperty("tags", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public string[]? Tags { get; set; }
+
+    /// <summary>
+    ///     The title of this message.
+    /// </summary>
+    [JsonProperty("title", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    public string? Title { get; set; }
+
+    /// <summary>
+    ///     The topic to send this message to.
+    ///     This parameter is set internally during the sending process, and should not be set manually by the user.
+    /// </summary>
+    [JsonProperty("topic", Required = Required.Always)]
+    internal string Topic { get; set; } = null!;
+
+    /// <summary>
+    ///     Whether to enable or disable caching for this message, as a string.
+    ///     This representation is used by API calls, and is hidden from end users.
+    /// </summary>
+    [JsonProperty("cache", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    private string CacheString { get; set; } = "yes";
+
+    /// <summary>
+    ///     The string representation of the delay to wait before sending this message.
+    ///     This representation is used by API calls, and is hidden from end users.
+    /// </summary>
+    [JsonProperty("delay", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    private string? DelayString { get; set; }
+
+    /// <summary>
+    ///     Whether to enable or disable sending this message to Firebase, as a string.
+    ///     This representation is used by API calls, and is hidden from end users.
+    /// </summary>
+    [JsonProperty("firebase", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    private string FirebaseString { get; set; } = "yes";
+
+    /// <summary>
+    ///     The priority level of this message, as an integer.
+    ///     This representation is used by API calls, and is hidden from end users.
+    /// </summary>
+    [JsonProperty("priority", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    private int? PriorityInt { get; set; }
+
+    /// <summary>
+    ///     Whether to enable or disable UnifiedPush for this message, as a string.
+    ///     This representation is used by API calls, and is hidden from end users.
+    /// </summary>
+    [JsonProperty("unifiedpush", Required = Required.AllowNull, NullValueHandling = NullValueHandling.Ignore)]
+    private int UnifiedPushInt { get; set; }
+
+    #endregion
 }

--- a/ntfy/Requests/TopicReservation.cs
+++ b/ntfy/Requests/TopicReservation.cs
@@ -1,4 +1,3 @@
-using NetTools.HTTP;
 using Newtonsoft.Json;
 
 namespace ntfy.Requests;
@@ -8,22 +7,6 @@ namespace ntfy.Requests;
 /// </summary>
 internal class TopicReservation
 {
-    #region JSON Properties
-
-    /// <summary>
-    ///     The name of the topic to reserve.
-    /// </summary>
-    [JsonProperty("topic", Required = Required.Always)]
-    internal string Topic { get; set; }
-    
-    /// <summary>
-    ///     The permission to grant to others for the topic.
-    /// </summary>
-    [JsonProperty("everyone", Required = Required.Always)]
-    internal string Permission { get; set; }
-
-    #endregion
-    
     /// <summary>
     ///     Construct a new <see cref="TopicReservation" /> instance.
     /// </summary>
@@ -41,6 +24,22 @@ internal class TopicReservation
     /// <returns>A JSON data string representation of this request payload.</returns>
     internal string ToData()
     {
-        return JsonSerialization.ConvertObjectToJson(this);
+        return JsonConvert.SerializeObject(this);
     }
+
+    #region JSON Properties
+
+    /// <summary>
+    ///     The name of the topic to reserve.
+    /// </summary>
+    [JsonProperty("topic", Required = Required.Always)]
+    internal string Topic { get; set; }
+
+    /// <summary>
+    ///     The permission to grant to others for the topic.
+    /// </summary>
+    [JsonProperty("everyone", Required = Required.Always)]
+    internal string Permission { get; set; }
+
+    #endregion
 }

--- a/ntfy/Requests/UserChangePassword.cs
+++ b/ntfy/Requests/UserChangePassword.cs
@@ -1,4 +1,3 @@
-using NetTools.HTTP;
 using Newtonsoft.Json;
 
 namespace ntfy.Requests;
@@ -8,22 +7,6 @@ namespace ntfy.Requests;
 /// </summary>
 internal class UserChangePassword
 {
-    #region JSON Properties
-
-    /// <summary>
-    ///     The old password of the user.
-    /// </summary>
-    [JsonProperty("password", Required = Required.Always)]
-    internal string OldPassword { get; set; }
-    
-    /// <summary>
-    ///     The new password of the user.
-    /// </summary>
-    [JsonProperty("new_password", Required = Required.Always)]
-    internal string NewPassword { get; set; }
-
-    #endregion
-    
     /// <summary>
     ///     Construct a new <see cref="UserChangePassword" /> instance.
     /// </summary>
@@ -41,6 +24,22 @@ internal class UserChangePassword
     /// <returns>A JSON data string representation of this request payload.</returns>
     internal string ToData()
     {
-        return JsonSerialization.ConvertObjectToJson(this);
+        return JsonConvert.SerializeObject(this);
     }
+
+    #region JSON Properties
+
+    /// <summary>
+    ///     The old password of the user.
+    /// </summary>
+    [JsonProperty("password", Required = Required.Always)]
+    internal string OldPassword { get; set; }
+
+    /// <summary>
+    ///     The new password of the user.
+    /// </summary>
+    [JsonProperty("new_password", Required = Required.Always)]
+    internal string NewPassword { get; set; }
+
+    #endregion
 }

--- a/ntfy/Requests/UserSignup.cs
+++ b/ntfy/Requests/UserSignup.cs
@@ -1,4 +1,3 @@
-using NetTools.HTTP;
 using Newtonsoft.Json;
 
 namespace ntfy.Requests;
@@ -8,22 +7,6 @@ namespace ntfy.Requests;
 /// </summary>
 internal class UserSignup
 {
-    #region JSON Properties
-
-    /// <summary>
-    ///     The username of the user to create.
-    /// </summary>
-    [JsonProperty("username", Required = Required.Always)]
-    internal string Username { get; set; }
-    
-    /// <summary>
-    ///     The password of the user to create.
-    /// </summary>
-    [JsonProperty("password", Required = Required.Always)]
-    internal string Password { get; set; }
-
-    #endregion
-    
     /// <summary>
     ///     Construct a new <see cref="UserSignup" /> instance.
     /// </summary>
@@ -41,6 +24,22 @@ internal class UserSignup
     /// <returns>A JSON data string representation of this request payload.</returns>
     internal string ToData()
     {
-        return JsonSerialization.ConvertObjectToJson(this);
+        return JsonConvert.SerializeObject(this);
     }
+
+    #region JSON Properties
+
+    /// <summary>
+    ///     The username of the user to create.
+    /// </summary>
+    [JsonProperty("username", Required = Required.Always)]
+    internal string Username { get; set; }
+
+    /// <summary>
+    ///     The password of the user to create.
+    /// </summary>
+    [JsonProperty("password", Required = Required.Always)]
+    internal string Password { get; set; }
+
+    #endregion
 }

--- a/ntfy/Responses/ServerHealthInfo.cs
+++ b/ntfy/Responses/ServerHealthInfo.cs
@@ -5,7 +5,7 @@ namespace ntfy.Responses;
 /// <summary>
 ///     Health information about the ntfy server.
 /// </summary>
-public abstract class ServerHealth
+public class ServerHealth
 {
     #region JSON Properties
 

--- a/ntfy/Responses/ServerInfo.cs
+++ b/ntfy/Responses/ServerInfo.cs
@@ -1,4 +1,3 @@
-using NetTools.HTTP;
 using Newtonsoft.Json;
 
 namespace ntfy.Responses;
@@ -8,52 +7,6 @@ namespace ntfy.Responses;
 /// </summary>
 public class ServerInfo
 {
-    #region JSON Properties
-    
-    /// <summary>
-    ///     The server's base URL.
-    /// </summary>
-    [JsonProperty("base_url")]
-    public string? BaseUrl { get; internal set; }
-
-    /// <summary>
-    ///     The server's root path.
-    /// </summary>
-    [JsonProperty("app_root")]
-    public string? AppRoot { get; internal set; }
-    
-    /// <summary>
-    ///     Whether the server allows login.
-    /// </summary>
-    [JsonProperty("enable_login")]
-    public bool LoginEnabled { get; internal set; }
-    
-    /// <summary>
-    ///     Whether the server allows signup.
-    /// </summary>
-    [JsonProperty("enable_signup")]
-    public bool SignupEnabled { get; internal set; }
-    
-    /// <summary>
-    ///     Whether the server allows payments.
-    /// </summary>
-    [JsonProperty("enable_payments")]
-    public bool PaymentsEnabled { get; internal set; }
-    
-    /// <summary>
-    ///     Whether the server allows topic reservations.
-    /// </summary>
-    [JsonProperty("enable_reservations")]
-    public bool TopicReservationsEnabled { get; internal set; }
-
-    /// <summary>
-    ///     A list of disallowed topics on the server.
-    /// </summary>
-    [JsonProperty("disallowed_topics")]
-    public string[]? DisallowedTopics { get; internal set; }
-
-    #endregion
-
     /// <summary>
     ///     Construct a new <see cref="ServerInfo" /> instance from the JavaScript response from the info endpoint.
     /// </summary>
@@ -82,7 +35,53 @@ public class ServerInfo
         json = json.Replace(" ", "");
 
         // deserialize JSON
-        var serverInfo = JsonSerialization.ConvertJsonToObject<ServerInfo>(json);
+        var serverInfo = JsonConvert.DeserializeObject<ServerInfo>(json);
         return serverInfo;
     }
+
+    #region JSON Properties
+
+    /// <summary>
+    ///     The server's base URL.
+    /// </summary>
+    [JsonProperty("base_url")]
+    public string? BaseUrl { get; internal set; }
+
+    /// <summary>
+    ///     The server's root path.
+    /// </summary>
+    [JsonProperty("app_root")]
+    public string? AppRoot { get; internal set; }
+
+    /// <summary>
+    ///     Whether the server allows login.
+    /// </summary>
+    [JsonProperty("enable_login")]
+    public bool LoginEnabled { get; internal set; }
+
+    /// <summary>
+    ///     Whether the server allows signup.
+    /// </summary>
+    [JsonProperty("enable_signup")]
+    public bool SignupEnabled { get; internal set; }
+
+    /// <summary>
+    ///     Whether the server allows payments.
+    /// </summary>
+    [JsonProperty("enable_payments")]
+    public bool PaymentsEnabled { get; internal set; }
+
+    /// <summary>
+    ///     Whether the server allows topic reservations.
+    /// </summary>
+    [JsonProperty("enable_reservations")]
+    public bool TopicReservationsEnabled { get; internal set; }
+
+    /// <summary>
+    ///     A list of disallowed topics on the server.
+    /// </summary>
+    [JsonProperty("disallowed_topics")]
+    public string[]? DisallowedTopics { get; internal set; }
+
+    #endregion
 }

--- a/ntfy/ntfy.csproj
+++ b/ntfy/ntfy.csproj
@@ -58,10 +58,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
-        <PackageReference Include="N8.NetTools.Crypto" Version="0.2.1" />
-        <PackageReference Include="N8.NetTools.HTTP" Version="0.2.0" />
+        <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0"/>
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0"/>
+        <PackageReference Include="N8.NetTools.Crypto" Version="0.2.1"/>
+        <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0"/>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
For a project, I need the latest versions of RestSharp. 
As your library meets my needs very well for NTFY, I took the liberty of contributing to your project to reference RestSharp directly.
